### PR TITLE
UPnPRegistry Causing Crashes on closure #3 in UPnPRegistry.add(_:) + 186

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/CoreOffice/XMLCoder.git", from: "0.13.1"),
-        .package(url: "https://github.com/httpswift/swifter", branch: "stable"),
-        .package(url: "https://github.com/robbiehanson/CocoaAsyncSocket", branch: "master"),
+        .package(url: "https://github.com/httpswift/swifter.git", branch: "stable"),
+        .package(url: "https://github.com/robbiehanson/CocoaAsyncSocket.git", branch: "master"),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "3.0.0"))
     ],
     targets: [

--- a/Source/UPnP/UPnPRegistry.swift
+++ b/Source/UPnP/UPnPRegistry.swift
@@ -185,17 +185,17 @@ public class UPnPRegistry {
     func typedService(device: UPnPDevice, serviceUrn: String) -> UPnPService? {
         Self.typedService(device: device, serviceUrn: serviceUrn, eventPublisher: eventPublisher, eventCallbackUrl: eventCallbackUrl)
     }
-
+    
     static func typedService(device: UPnPDevice, serviceUrn: String, eventPublisher: AnyPublisher<(String, Data), Never>? = nil, eventCallbackUrl: URL? = nil) -> UPnPService? {
         guard let deviceServices = device.deviceDefinition?.device.serviceList?.service,
-              let deviceService = deviceServices.first(where: { $0.serviceType == serviceUrn }) else { return nil }
+              let deviceService = deviceServices.first(where: { $0.serviceType == serviceUrn }),
+              let scheme = device.url.scheme,
+              let host = device.url.host,
+              let port = device.url.port,
+              let baseURL = URL(string: "\(scheme)://\(host):\(port)"),
+              let controlUrl = URL(string: deviceService.controlURL, relativeTo: baseURL),
+              let scpdUrl = URL(string: deviceService.SCPDURL, relativeTo: baseURL) else { return nil }
         
-        guard let scheme = device.url.scheme, let host = device.url.host, let port = device.url.port else { return nil }
-        
-        let baseURL = URL(string: "\(scheme)://\(host):\(port)")
-        
-        guard let controlUrl = URL(string: deviceService.controlURL, relativeTo: baseURL) else { return nil }
-        guard let scpdUrl = URL(string: deviceService.SCPDURL, relativeTo: baseURL) else { return nil }
         let eventUrl = URL(string: deviceService.eventSubURL, relativeTo: baseURL)
         
         switch serviceUrn {

--- a/Source/UPnP/UPnPRegistry.swift
+++ b/Source/UPnP/UPnPRegistry.swift
@@ -190,193 +190,200 @@ public class UPnPRegistry {
         guard let deviceServices = device.deviceDefinition?.device.serviceList?.service,
               let deviceService = deviceServices.first(where: { $0.serviceType == serviceUrn }) else { return nil }
         
-        let baseURL = URL(string: "\(device.url.scheme!)://\(device.url.host!):\(device.url.port!)")
+        guard let scheme = device.url.scheme, let host = device.url.host, let port = device.url.port else { return nil }
+        
+        let baseURL = URL(string: "\(scheme)://\(host):\(port)")
+        
+        guard let controlUrl = URL(string: deviceService.controlURL, relativeTo: baseURL) else { return nil }
+        guard let scpdUrl = URL(string: deviceService.SCPDURL, relativeTo: baseURL) else { return nil }
+        let eventUrl = URL(string: deviceService.eventSubURL, relativeTo: baseURL)
+        
         switch serviceUrn {
         case "urn:av-openhome-org:service:Credentials:1":
             return OpenHomeCredentials1Service(device: device,
-                                               controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                               scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                               eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                               controlUrl: controlUrl,
+                                               scpdUrl: scpdUrl,
+                                               eventUrl: eventUrl,
                                                serviceType: deviceService.serviceType,
                                                serviceId: deviceService.serviceId,
                                                eventPublisher: eventPublisher,
                                                eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Info:1":
             return OpenHomeInfo1Service(device: device,
-                                        controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                        scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                        eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                        controlUrl: controlUrl,
+                                        scpdUrl: scpdUrl,
+                                        eventUrl: eventUrl,
                                         serviceType: deviceService.serviceType,
                                         serviceId: deviceService.serviceId,
                                         eventPublisher: eventPublisher,
                                         eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:OAuth:1":
             return OpenHomeOAuth1Service(device: device,
-                                         controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                         scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                         eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                         controlUrl: controlUrl,
+                                         scpdUrl: scpdUrl,
+                                         eventUrl: eventUrl,
                                          serviceType: deviceService.serviceType,
                                          serviceId: deviceService.serviceId,
                                          eventPublisher: eventPublisher,
                                          eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Pins:1":
             return OpenHomePins1Service(device: device,
-                                        controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                        scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                        eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                        controlUrl: controlUrl,
+                                        scpdUrl: scpdUrl,
+                                        eventUrl: eventUrl,
                                         serviceType: deviceService.serviceType,
                                         serviceId: deviceService.serviceId,
                                         eventPublisher: eventPublisher,
                                         eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Playlist:1":
             return OpenHomePlaylist1Service(device: device,
-                                            controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                            scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                            eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                            controlUrl: controlUrl,
+                                            scpdUrl: scpdUrl,
+                                            eventUrl: eventUrl,
                                             serviceType: deviceService.serviceType,
                                             serviceId: deviceService.serviceId,
                                             eventPublisher: eventPublisher,
                                             eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:PlaylistManager:1":
             return OpenHomePlaylistManager1Service(device: device,
-                                                   controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                                   scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                                   eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                                   controlUrl: controlUrl,
+                                                   scpdUrl: scpdUrl,
+                                                   eventUrl: eventUrl,
                                                    serviceType: deviceService.serviceType,
                                                    serviceId: deviceService.serviceId,
                                                    eventPublisher: eventPublisher,
                                                    eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Product:1":
             return OpenHomeProduct1Service(device: device,
-                                           controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                           scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                           eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                           controlUrl: controlUrl,
+                                           scpdUrl: scpdUrl,
+                                           eventUrl: eventUrl,
                                            serviceType: deviceService.serviceType,
                                            serviceId: deviceService.serviceId,
                                            eventPublisher: eventPublisher,
                                            eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Product:2":
             return OpenHomeProduct2Service(device: device,
-                                           controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                           scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                           eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                           controlUrl: controlUrl,
+                                           scpdUrl: scpdUrl,
+                                           eventUrl: eventUrl,
                                            serviceType: deviceService.serviceType,
                                            serviceId: deviceService.serviceId,
                                            eventPublisher: eventPublisher,
                                            eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Radio:1":
             return OpenHomeRadio1Service(device: device,
-                                         controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                         scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                         eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                         controlUrl: controlUrl,
+                                         scpdUrl: scpdUrl,
+                                         eventUrl: eventUrl,
                                          serviceType: deviceService.serviceType,
                                          serviceId: deviceService.serviceId,
                                          eventPublisher: eventPublisher,
                                          eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Time:1":
             return OpenHomeTime1Service(device: device,
-                                        controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                        scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                        eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                        controlUrl: controlUrl,
+                                        scpdUrl: scpdUrl,
+                                        eventUrl: eventUrl,
                                         serviceType: deviceService.serviceType,
                                         serviceId: deviceService.serviceId,
                                         eventPublisher: eventPublisher,
                                         eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Transport:1":
             return OpenHomeTransport1Service(device: device,
-                                             controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                             scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                             eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                             controlUrl: controlUrl,
+                                             scpdUrl: scpdUrl,
+                                             eventUrl: eventUrl,
                                              serviceType: deviceService.serviceType,
                                              serviceId: deviceService.serviceId,
                                              eventPublisher: eventPublisher,
                                              eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Volume:1":
             return OpenHomeVolume1Service(device: device,
-                                          controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                          scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                          eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                          controlUrl: controlUrl,
+                                          scpdUrl: scpdUrl,
+                                          eventUrl: eventUrl,
                                           serviceType: deviceService.serviceType,
                                           serviceId: deviceService.serviceId,
                                           eventPublisher: eventPublisher,
                                           eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Volume:2":
             return OpenHomeVolume2Service(device: device,
-                                          controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                          scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                          eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                          controlUrl: controlUrl,
+                                          scpdUrl: scpdUrl,
+                                          eventUrl: eventUrl,
                                           serviceType: deviceService.serviceType,
                                           serviceId: deviceService.serviceId,
                                           eventPublisher: eventPublisher,
                                           eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Config:1":
             return OpenHomeConfig1Service(device: device,
-                                          controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                          scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                          eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                          controlUrl: controlUrl,
+                                          scpdUrl: scpdUrl,
+                                          eventUrl: eventUrl,
                                           serviceType: deviceService.serviceType,
                                           serviceId: deviceService.serviceId,
                                           eventPublisher: eventPublisher,
                                           eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Sender:1":
             return OpenHomeSender1Service(device: device,
-                                          controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                          scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                          eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                          controlUrl: controlUrl,
+                                          scpdUrl: scpdUrl,
+                                          eventUrl: eventUrl,
                                           serviceType: deviceService.serviceType,
                                           serviceId: deviceService.serviceId,
                                           eventPublisher: eventPublisher,
                                           eventCallbackUrl: eventCallbackUrl)
         case "urn:av-openhome-org:service:Receiver:1":
             return OpenHomeReceiver1Service(device: device,
-                                          controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                          scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                          eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                            controlUrl: controlUrl,
+                                            scpdUrl: scpdUrl,
+                                            eventUrl: eventUrl,
                                           serviceType: deviceService.serviceType,
                                           serviceId: deviceService.serviceId,
                                           eventPublisher: eventPublisher,
                                           eventCallbackUrl: eventCallbackUrl)
         case "urn:schemas-upnp-org:service:ConnectionManager:1":
             return ConnectionManager1Service(device: device,
-                                             controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                             scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                             eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                             controlUrl: controlUrl,
+                                             scpdUrl: scpdUrl,
+                                             eventUrl: eventUrl,
                                              serviceType: deviceService.serviceType,
                                              serviceId: deviceService.serviceId,
                                              eventPublisher: eventPublisher,
                                              eventCallbackUrl: eventCallbackUrl)
         case "urn:schemas-upnp-org:service:ContentDirectory:1":
             return ContentDirectory1Service(device: device,
-                                            controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                            scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                            eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                            controlUrl: controlUrl,
+                                            scpdUrl: scpdUrl,
+                                            eventUrl: eventUrl,
                                             serviceType: deviceService.serviceType,
                                             serviceId: deviceService.serviceId,
                                             eventPublisher: eventPublisher,
                                             eventCallbackUrl: eventCallbackUrl)
         case "urn:schemas-upnp-org:service:AVTransport:1":
             return AVTransport1Service(device: device,
-                                       controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                       scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                       eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                       controlUrl: controlUrl,
+                                       scpdUrl: scpdUrl,
+                                       eventUrl: eventUrl,
                                        serviceType: deviceService.serviceType,
                                        serviceId: deviceService.serviceId,
                                        eventPublisher: eventPublisher,
                                        eventCallbackUrl: eventCallbackUrl)
         case "urn:schemas-upnp-org:service:RenderingControl:1":
             return RenderingControl1Service(device: device,
-                                            controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                                            scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                                            eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                                            controlUrl: controlUrl,
+                                            scpdUrl: scpdUrl,
+                                            eventUrl: eventUrl,
                                             serviceType: deviceService.serviceType,
                                             serviceId: deviceService.serviceId,
                                             eventPublisher: eventPublisher,
                                             eventCallbackUrl: eventCallbackUrl)
         default:
             return UPnPService(device: device,
-                               controlUrl: URL(string: deviceService.controlURL, relativeTo: baseURL)!,
-                               scpdUrl: URL(string: deviceService.SCPDURL, relativeTo: baseURL)!,
-                               eventUrl: URL(string: deviceService.eventSubURL, relativeTo: baseURL),
+                               controlUrl: controlUrl,
+                               scpdUrl: scpdUrl,
+                               eventUrl: eventUrl,
                                serviceType: deviceService.serviceType,
                                serviceId: deviceService.serviceId,
                                eventPublisher: eventPublisher,


### PR DESCRIPTION
Many users have encountered crashes due to unsafe processing in the UPnPRegistry component of the SwiftUPnP library. After investigating the issue, I identified the root cause and have rewritten the affected code to ensure safe and reliable processing.

I have prepared a fix and would like to contribute it to the library to prevent future occurrences of this problem.

Issue #9 